### PR TITLE
Add Check In route and Add Streak Calculation Logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "dotenv": "^17.0.0",
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
+        "moment-timezone": "^0.6.0",
         "mongoose": "^8.16.1",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.1"
@@ -4038,6 +4039,27 @@
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.6.0.tgz",
+      "integrity": "sha512-ldA5lRNm3iJCWZcBCab4pnNL3HSZYXVb/3TYr75/1WCTWYuTqYUb5f/S384pncYjJ88lbO8Z4uPDvmoluHJc8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "moment": "^2.29.4"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/mongodb": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dotenv": "^17.0.0",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
+    "moment-timezone": "^0.6.0",
     "mongoose": "^8.16.1",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1"

--- a/src/config/loadRoutes.js
+++ b/src/config/loadRoutes.js
@@ -19,6 +19,8 @@ function loadRoutes(app) {
     app.use("/api/habit", editHabitRoute);
     const deleteHabitRoute = require("../route/deleteHabit");
     app.use("/api/habit", deleteHabitRoute);
+    const addCheckInRoute = require("../route/addCheckIn");
+    app.use("/api/check-in", addCheckInRoute);
 }
 
 module.exports = loadRoutes;

--- a/src/config/swagger.js
+++ b/src/config/swagger.js
@@ -69,7 +69,7 @@ function setupSwagger(app) {
                                 example: "2025-07-18T02:24:56.308Z"
                             }
                         },
-                        required: ["id", "name", "streak", "createdAt"]
+                        required: ["id", "name", "createdAt"]
                     },
                     // Common error schema used server-wide.
                     Error: {

--- a/src/controller/addCheckInController.js
+++ b/src/controller/addCheckInController.js
@@ -2,6 +2,20 @@ const CheckIn = require("../model/CheckIn");
 const { toCleanCheckIn } = require("../util/toCleanCheckIn");
 const moment = require("moment-timezone");
 
+/**
+ * Adds a new check in for the authenticated user.
+ * 
+ * @param {Object} req - Express request object
+ * @param {string} req.user.userId - The authenticated user's ID (injected by JWT middleware)
+ * @param {string} req.user.timezone - The authenticated user's timezone (injected by JWT middleware)
+ * @param {string} req.body.habitId - The id associated with the habit for which to create a check in for
+ * @param {Object} res - Express response object
+ * 
+ * @returns {Object} JSON response:
+ *   - 201: Check in created
+ *   - 400: Habit id missing or already checked in for today
+ *   - 500: Internal server error
+ */
 async function addCheckIn(req, res) {
     try {
         const { userId, timezone } = req.user;

--- a/src/controller/addCheckInController.js
+++ b/src/controller/addCheckInController.js
@@ -1,0 +1,40 @@
+const CheckIn = require("../model/CheckIn");
+const { toCleanCheckIn } = require("../util/toCleanCheckIn");
+const moment = require("moment-timezone");
+
+async function addCheckIn(req, res) {
+    try {
+        const { userId, timezone } = req.user;
+        const { habitId } = req.body;
+
+        if (!habitId) {
+            return res.status(400).json({ error: "habitId is required" });
+        }
+
+        // Get current time in user's timezone
+        const now = moment().tz(timezone);
+
+        // Calculate habitDay as YYYY-MM-DD
+        const habitDay = now.format("YYYY-MM-DD");
+
+        // Check for existing check in for this day
+        const existingCheckIn = await CheckIn.findOne({ userId, habitId, habitDay });
+        if (existingCheckIn) {
+            return res.status(400).json({ error: "Already checked in for today" });
+        }
+
+        // Create new check in
+        const checkIn = await CheckIn.create({
+            userId,
+            habitId,
+            habitDay
+        });
+
+        return res.status(201).json({ message: "Check in created", checkIn: toCleanCheckIn(checkIn) });
+    } catch (err) {
+        console.error("Error creating check in:", err);
+        return res.status(500).json({ error: "Internal server error" });
+    }
+}
+
+module.exports = { addCheckIn };

--- a/src/controller/addHabitController.js
+++ b/src/controller/addHabitController.js
@@ -30,7 +30,7 @@ async function addHabit(req, res) {
 
         await habit.save();
 
-        return res.status(201).json({ message: "Habit created", habit: toCleanHabit(habit) });
+        return res.status(201).json({ message: "Habit created", habit: toCleanHabit(habit, 0) });
     } catch (err) {
         console.error("Error creating habit:", err);
         return res.status(500).json({ error: "Internal server error" });

--- a/src/controller/deleteHabitController.js
+++ b/src/controller/deleteHabitController.js
@@ -1,4 +1,5 @@
 const Habit = require("../model/Habit");
+const CheckIn = require("../model/CheckIn");
 
 /**
  * Deletes a habit for the authenticated user.
@@ -22,6 +23,8 @@ async function deleteHabit(req, res) {
         if (!habit) {
             return res.status(404).json({ error: "Habit not found" });
         }
+
+        await CheckIn.deleteMany({ habitId: id });
 
         return res.status(200).json({ message: "Habit deleted" });
     } catch (err) {

--- a/src/controller/loginController.js
+++ b/src/controller/loginController.js
@@ -29,7 +29,7 @@ async function loginUser(req, res) {
         }
 
         const token = jwt.sign(
-            { userId: user._id },
+            { userId: user._id, timezone: user.timezone },
             process.env.JWT_SECRET,
             { expiresIn: "7d" }
         );

--- a/src/controller/loginController.js
+++ b/src/controller/loginController.js
@@ -1,6 +1,6 @@
 const User = require("../model/User");
 const bcrypt = require("bcryptjs");
-const jwt = require("jsonwebtoken");
+const { signJwt } = require("../util/signJwt");
 
 /**
  * Authenticates a user and returns a JWT if login is successful.
@@ -28,12 +28,7 @@ async function loginUser(req, res) {
             return res.status(400).json({ error: "Invalid email or password" });
         }
 
-        const token = jwt.sign(
-            { userId: user._id, timezone: user.timezone },
-            process.env.JWT_SECRET,
-            { expiresIn: "7d" }
-        );
-
+        const token = signJwt(user);
         return res.status(200).json({ token });
     } catch (err) {
         console.error("500 error:", err);

--- a/src/controller/signupController.js
+++ b/src/controller/signupController.js
@@ -35,9 +35,10 @@ async function signupUser(req, res) {
         });
         await user.save();
 
+        // TODO: Consolidate common token generation logic to a util.
         // Generate JWT
         const token = jwt.sign(
-            { userId: user._id },
+            { userId: user._id, timezone: user.timezone },
             process.env.JWT_SECRET,
             { expiresIn: "7d" }
         );

--- a/src/controller/signupController.js
+++ b/src/controller/signupController.js
@@ -1,5 +1,5 @@
 const bcrypt = require("bcryptjs");
-const jwt = require("jsonwebtoken");
+const { signJwt } = require("../util/signJwt");
 const User = require("../model/User");
 
 /**
@@ -35,14 +35,7 @@ async function signupUser(req, res) {
         });
         await user.save();
 
-        // TODO: Consolidate common token generation logic to a util.
-        // Generate JWT
-        const token = jwt.sign(
-            { userId: user._id, timezone: user.timezone },
-            process.env.JWT_SECRET,
-            { expiresIn: "7d" }
-        );
-
+        const token = signJwt(user);
         return res.status(201).json({ token });
     } catch (err) {
         console.error("500 error:", err);

--- a/src/controller/timezoneController.js
+++ b/src/controller/timezoneController.js
@@ -1,7 +1,9 @@
 const User = require("../model/User");
+const CheckIn = require("../model/CheckIn");
 
 /**
- * Updates the authenticated user's timezone.
+ * Updates the authenticated user's timezone. All a user's streaks are deleted on timezone change to avoid 
+ * complicated logic in streak calculation.
  * 
  * @param {Object} req - Express request object.
  * @param {Object} req.user - Decoded JWT payload containing the userId.
@@ -22,16 +24,17 @@ async function updateTimezone(req, res) {
             return res.status(400).json({ error: "Timezone is required" });
         }
 
-        // TODO: Reset streaks logic would go here (once you track them). For now, just update the timezone.
         const user = await User.findByIdAndUpdate(
             userId,
-            { timezone /* , streak: 0 */ },
+            { timezone },
             { new: true }
         );
 
         if (!user) {
             return res.status(404).json({ error: "User not found" });
         }
+
+        await CheckIn.deleteMany({ userId: userId });
 
         return res.status(200).json({ message: "Timezone updated", timezone: user.timezone });
     } catch (err) {

--- a/src/model/CheckIn.js
+++ b/src/model/CheckIn.js
@@ -1,0 +1,22 @@
+const mongoose = require("mongoose");
+
+const checkInSchema = new mongoose.Schema({
+    userId: {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: "User",
+        required: true
+    },
+    habitId: {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: "Habit",
+        required: true,
+    },
+    habitDay: {
+        type: Date,
+        required: true
+    }
+}, {
+    timestamps: true
+});
+
+module.exports = mongoose.model("CheckIn", checkInSchema);

--- a/src/model/CheckIn.js
+++ b/src/model/CheckIn.js
@@ -12,11 +12,14 @@ const checkInSchema = new mongoose.Schema({
         required: true,
     },
     habitDay: {
-        type: Date,
+        type: String,
         required: true
     }
 }, {
     timestamps: true
 });
+
+// Prevent duplicate check ins for the same habitDay.
+checkInSchema.index({ userId: 1, habitId: 1, habitDay: 1 }, { unique: true });
 
 module.exports = mongoose.model("CheckIn", checkInSchema);

--- a/src/model/Habit.js
+++ b/src/model/Habit.js
@@ -10,13 +10,6 @@ const habitSchema = new mongoose.Schema({
         type: String,
         required: true,
         trim: true
-    },
-    streak: {
-        type: Number,
-        default: 0
-    },
-    lastCompleted: {
-        type: Date
     }
 }, {
     timestamps: true

--- a/src/route/addCheckIn.js
+++ b/src/route/addCheckIn.js
@@ -1,0 +1,77 @@
+const express = require("express");
+const router = express.Router();
+const { authenticateToken } = require("../middleware/authentication");
+const { addCheckIn } = require("../controller/addCheckInController");
+
+/**
+ * @swagger
+ * /api/check-in:
+ *   post:
+ *     summary: Add a check in for the authenticated user
+ *     tags:
+ *       - Check Ins
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - habitId
+ *             properties:
+ *               habitId:
+ *                 type: string
+ *                 example: "64b9f3a8b8c7a2d1e4d9e123"
+ *     responses:
+ *       201:
+ *         description: Check in created successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Check in created
+ *                 checkIn:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: string
+ *                       example: "64ba0b20b8c7a2d1e4d9e456"
+ *                     habitId:
+ *                       type: string
+ *                       example: "64b9f3a8b8c7a2d1e4d9e123"
+ *                     habitDay:
+ *                       type: string
+ *                       format: date
+ *                       example: "2025-07-24"
+ *                   required: [ "id", "habitId", "habitDay" ]
+ *               required: [ "message", "checkIn" ]
+ *       400:
+ *         description: Bad request – missing habitId or already checked in
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: "#/components/schemas/Error"
+ *             examples:
+ *               MissingHabitId:
+ *                 summary: Missing habit id
+ *                 value:
+ *                   error: "habitId is required"
+ *               DuplicateCheckIn:
+ *                 summary: Check in already recorded for today
+ *                 value:
+ *                   error: "Already checked in for today"
+ *       401:
+ *         $ref: "#/components/responses/UnauthorizedError"
+ *       403:
+ *         $ref: "#/components/responses/ForbiddenError"
+ *       500:
+ *         $ref: "#/components/responses/InternalServerError"
+ */
+router.post("/", authenticateToken, addCheckIn);
+
+module.exports = router;

--- a/src/route/timezone.js
+++ b/src/route/timezone.js
@@ -7,7 +7,7 @@ const { updateTimezone } = require("../controller/timezoneController");
  * @swagger
  * /api/timezone:
  *   patch:
- *     summary: Update the timezone for the authenticated user
+ *     summary: Update the timezone for the authenticated user. This action also resets the user's streaks to avoid confusing streak calculation logic for each habit.
  *     tags: [User]
  *     security:
  *       - bearerAuth: []

--- a/src/util/signJwt.js
+++ b/src/util/signJwt.js
@@ -1,0 +1,21 @@
+const jwt = require("jsonwebtoken");
+
+/**
+ * Generates a JSON Web Token (JWT) for the given user. The token includes 
+ * the user's ID and timezone and is signed using the server's secret. It
+ * expires in 7 days.
+ *
+ * @param {Object} user - The user object
+ * @param {string} user._id - The user's unique id
+ * @param {string} user.timezone - The user's timezone
+ * @returns {string} A signed JWT
+ */
+function signJwt(user) {
+    return jwt.sign(
+        { userId: user._id, timezone: user.timezone },
+        process.env.JWT_SECRET,
+        { expiresIn: "7d" }
+    );
+}
+
+module.exports = { signJwt };

--- a/src/util/toCleanCheckIn.js
+++ b/src/util/toCleanCheckIn.js
@@ -1,0 +1,16 @@
+/**
+ * Transforms a Check In Mongoose document into a plain object
+ * suitable for API responses.
+ *
+ * @param {Object} checkIn - The Check In document from the database.
+ * @returns {Object} A plain object with selected check in fields.
+ */
+function toCleanCheckIn(checkIn) {
+    return {
+        id: checkIn._id.toString(),
+        habitId: checkIn.habitId,
+        habitDay: checkIn.habitDay
+    };
+}
+
+module.exports = { toCleanCheckIn };

--- a/src/util/toCleanHabit.js
+++ b/src/util/toCleanHabit.js
@@ -3,14 +3,15 @@
  * suitable for API responses.
  *
  * @param {Object} habit - The Habit document from the database.
+ * @param {Number} streak - Streak derived by summing the number of Check In entries associated with this Habit.
  * @returns {Object} A plain object with selected habit fields.
  */
-function toCleanHabit(habit) {
+function toCleanHabit(habit, streak) {
     return {
         id: habit._id.toString(),
         name: habit.name,
-        streak: habit.streak,
         createdAt: habit.createdAt,
+        streak: streak
     };
 }
 

--- a/test/controller/addCheckInController.test.js
+++ b/test/controller/addCheckInController.test.js
@@ -1,0 +1,85 @@
+const { addCheckIn } = require("../../src/controller/addCheckInController");
+const CheckIn = require("../../src/model/CheckIn");
+const { toCleanCheckIn } = require("../../src/util/toCleanCheckIn");
+const moment = require("moment-timezone");
+const { createMockRes } = require("../testUtils");
+jest.mock("../../src/model/CheckIn");
+jest.mock("../../src/util/toCleanCheckIn");
+
+describe("addCheckIn", () => {
+    let req, res;
+
+    beforeEach(() => {
+        req = {
+            user: {
+                userId: "user123",
+                timezone: "America/New_York"
+            },
+            body: {
+                habitId: "habit456"
+            }
+        };
+
+        res = createMockRes();
+
+        jest.spyOn(console, "error").mockImplementation(() => { });
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it("should create a new check in and return 201", async () => {
+        const mockCheckIn = {
+            _id: "newId",
+            userId: "user123",
+            habitId: "habit456",
+            habitDay: moment().tz(req.user.timezone).format("YYYY-MM-DD")
+        };
+        CheckIn.findOne.mockResolvedValue(null);
+        CheckIn.create.mockResolvedValue(mockCheckIn);
+        toCleanCheckIn.mockReturnValue({ id: "newId", habitDay: mockCheckIn.habitDay });
+        await addCheckIn(req, res);
+
+        expect(CheckIn.create).toHaveBeenCalledWith({
+            userId: "user123",
+            habitId: "habit456",
+            habitDay: mockCheckIn.habitDay
+        });
+        expect(res.status).toHaveBeenCalledWith(201);
+        expect(res.json).toHaveBeenCalledWith({
+            message: "Check in created",
+            checkIn: { id: "newId", habitDay: mockCheckIn.habitDay }
+        });
+    });
+
+    it("should return 400 if habitId is missing", async () => {
+        req.body.habitId = undefined;
+        await addCheckIn(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json).toHaveBeenCalledWith({ error: "habitId is required" });
+    });
+
+    it("should return 400 if already checked in today", async () => {
+        const today = moment().tz(req.user.timezone).format("YYYY-MM-DD");
+        CheckIn.findOne.mockResolvedValue({ _id: "existingId", habitDay: today });
+        await addCheckIn(req, res);
+
+        expect(CheckIn.findOne).toHaveBeenCalledWith({
+            userId: "user123",
+            habitId: "habit456",
+            habitDay: today
+        });
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json).toHaveBeenCalledWith({ error: "Already checked in for today" });
+    });
+
+    it("should handle unexpected errors and return 500", async () => {
+        CheckIn.findOne.mockRejectedValue(new Error("DB error"));
+        await addCheckIn(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(500);
+        expect(res.json).toHaveBeenCalledWith({ error: "Internal server error" });
+    });
+});

--- a/test/controller/addHabitController.test.js
+++ b/test/controller/addHabitController.test.js
@@ -28,7 +28,6 @@ describe("addHabit", () => {
             _id: "123",
             userId: "user123",
             name: "Drink Water",
-            streak: 0,
             createdAt: "2025-07-17T14:23:45.123Z",
             save: mockSave,
         }));
@@ -42,8 +41,8 @@ describe("addHabit", () => {
             habit: expect.objectContaining({
                 id: "123",
                 name: "Drink Water",
-                streak: 0,
-                createdAt: "2025-07-17T14:23:45.123Z"
+                createdAt: "2025-07-17T14:23:45.123Z",
+                streak: 0
             }),
         });
     });

--- a/test/controller/deleteHabitController.test.js
+++ b/test/controller/deleteHabitController.test.js
@@ -1,7 +1,9 @@
 const { deleteHabit } = require("../../src/controller/deleteHabitController");
 const Habit = require("../../src/model/Habit");
+const CheckIn = require("../../src/model/CheckIn");
 const { createMockRes } = require("../testUtils");
 jest.mock("../../src/model/Habit");
+jest.mock("../../src/model/CheckIn");
 
 describe("deleteHabit", () => {
     let req, res;
@@ -33,6 +35,7 @@ describe("deleteHabit", () => {
             _id: "habit456",
             userId: "user123",
         });
+        expect(CheckIn.deleteMany).toHaveBeenCalledWith({ habitId: "habit456" });
         expect(res.status).toHaveBeenCalledWith(200);
         expect(res.json).toHaveBeenCalledWith({ message: "Habit deleted" });
     });

--- a/test/controller/editHabitController.test.js
+++ b/test/controller/editHabitController.test.js
@@ -26,7 +26,6 @@ describe("editHabit", () => {
         const mockHabit = {
             _id: "habit123",
             name: "Old Habit Name",
-            streak: 3,
             createdAt: new Date("2023-01-01"),
             save: jest.fn(),
         };
@@ -41,7 +40,6 @@ describe("editHabit", () => {
             habit: {
                 id: "habit123",
                 name: "New Habit Name",
-                streak: 3,
                 createdAt: new Date("2023-01-01"),
             },
         });

--- a/test/controller/loginController.test.js
+++ b/test/controller/loginController.test.js
@@ -17,7 +17,7 @@ describe("loginUser", () => {
     it("returns 200 and token for valid credentials", async () => {
         const req = { body: { email: "test@example.com", password: "password123" } };
         const res = createMockRes();
-        const mockUser = { _id: "user123", password: "hashedPassword" };
+        const mockUser = { _id: "user123", password: "hashedPassword", timezone: "America/New_York" };
         User.findOne = jest.fn().mockResolvedValue(mockUser);
         bcrypt.compare = jest.fn().mockResolvedValue(true);
         jwt.sign = jest.fn().mockReturnValue("fake-jwt-token");
@@ -27,7 +27,7 @@ describe("loginUser", () => {
         expect(User.findOne).toHaveBeenCalledWith({ email: "test@example.com" });
         expect(bcrypt.compare).toHaveBeenCalledWith("password123", "hashedPassword");
         expect(jwt.sign).toHaveBeenCalledWith(
-            { userId: "user123" },
+            { userId: "user123", timezone: "America/New_York" },
             process.env.JWT_SECRET,
             { expiresIn: "7d" }
         );

--- a/test/controller/loginController.test.js
+++ b/test/controller/loginController.test.js
@@ -1,8 +1,10 @@
 const { loginUser } = require("../../src/controller/loginController");
 const User = require("../../src/model/User");
 const bcrypt = require("bcryptjs");
-const jwt = require("jsonwebtoken");
+const { signJwt } = require("../../src/util/signJwt");
 const { createMockRes } = require("../testUtils");
+
+jest.mock("../../src/util/signJwt");
 
 describe("loginUser", () => {
 
@@ -20,17 +22,15 @@ describe("loginUser", () => {
         const mockUser = { _id: "user123", password: "hashedPassword", timezone: "America/New_York" };
         User.findOne = jest.fn().mockResolvedValue(mockUser);
         bcrypt.compare = jest.fn().mockResolvedValue(true);
-        jwt.sign = jest.fn().mockReturnValue("fake-jwt-token");
-
+        signJwt.mockReturnValue("fake-jwt-token");
         await loginUser(req, res);
 
         expect(User.findOne).toHaveBeenCalledWith({ email: "test@example.com" });
         expect(bcrypt.compare).toHaveBeenCalledWith("password123", "hashedPassword");
-        expect(jwt.sign).toHaveBeenCalledWith(
-            { userId: "user123", timezone: "America/New_York" },
-            process.env.JWT_SECRET,
-            { expiresIn: "7d" }
-        );
+        expect(signJwt).toHaveBeenCalledWith(expect.objectContaining({
+            _id: "user123",
+            timezone: "America/New_York"
+        }));
         expect(res.status).toHaveBeenCalledWith(200);
         expect(res.json).toHaveBeenCalledWith({ token: "fake-jwt-token" });
     });

--- a/test/controller/signupController.test.js
+++ b/test/controller/signupController.test.js
@@ -1,12 +1,12 @@
 const { signupUser } = require("../../src/controller/signupController");
 const User = require("../../src/model/User");
 const bcrypt = require("bcryptjs");
-const jwt = require("jsonwebtoken");
+const { signJwt } = require("../../src/util/signJwt");
 const { createMockRes } = require("../testUtils");
 
 jest.mock("../../src/model/User");
 jest.mock("bcryptjs");
-jest.mock("jsonwebtoken");
+jest.mock("../../src/util/signJwt");
 
 describe("signupUser", () => {
     beforeEach(() => {
@@ -24,7 +24,7 @@ describe("signupUser", () => {
         const res = createMockRes();
         User.findOne.mockResolvedValue(null);
         bcrypt.hash.mockResolvedValue("hashed_password");
-        jwt.sign.mockReturnValue("fake_jwt_token");
+        signJwt.mockReturnValue("fake_jwt_token");
         const mockSave = jest.fn().mockResolvedValue();
         User.mockImplementation(() => ({
             save: mockSave,
@@ -35,11 +35,10 @@ describe("signupUser", () => {
 
         expect(User.findOne).toHaveBeenCalledWith({ email: "test@example.com" });
         expect(bcrypt.hash).toHaveBeenCalledWith("123456", 10);
-        expect(jwt.sign).toHaveBeenCalledWith(
-            { userId: "user123", timezone: "America/New_York" },
-            process.env.JWT_SECRET,
-            { expiresIn: "7d" }
-        );
+        expect(signJwt).toHaveBeenCalledWith(expect.objectContaining({
+            _id: "user123",
+            timezone: "America/New_York"
+        }));
         expect(res.status).toHaveBeenCalledWith(201);
         expect(res.json).toHaveBeenCalledWith({ token: "fake_jwt_token" });
     });

--- a/test/controller/signupController.test.js
+++ b/test/controller/signupController.test.js
@@ -19,7 +19,7 @@ describe("signupUser", () => {
 
     it("should return 201 and a token on successful signup", async () => {
         const req = {
-            body: { email: "test@example.com", password: "123456", timezone: "UTC" },
+            body: { email: "test@example.com", password: "123456", timezone: "America/New_York" },
         };
         const res = createMockRes();
         User.findOne.mockResolvedValue(null);
@@ -29,13 +29,14 @@ describe("signupUser", () => {
         User.mockImplementation(() => ({
             save: mockSave,
             _id: "user123",
+            timezone: "America/New_York"
         }));
         await signupUser(req, res);
 
         expect(User.findOne).toHaveBeenCalledWith({ email: "test@example.com" });
         expect(bcrypt.hash).toHaveBeenCalledWith("123456", 10);
         expect(jwt.sign).toHaveBeenCalledWith(
-            { userId: "user123" },
+            { userId: "user123", timezone: "America/New_York" },
             process.env.JWT_SECRET,
             { expiresIn: "7d" }
         );

--- a/test/controller/timezoneController.test.js
+++ b/test/controller/timezoneController.test.js
@@ -1,8 +1,10 @@
 const { updateTimezone } = require("../../src/controller/timezoneController");
 const User = require("../../src/model/User");
+const CheckIn = require("../../src/model/CheckIn");
 const { createMockRes } = require("../testUtils");
 
 jest.mock("../../src/model/User");
+jest.mock("../../src/model/CheckIn");
 
 describe("updateTimezone", () => {
     let req, res;
@@ -31,6 +33,9 @@ describe("updateTimezone", () => {
             "user123",
             { timezone: "America/New_York" },
             { new: true }
+        );
+        expect(CheckIn.deleteMany).toHaveBeenCalledWith(
+            { userId: "user123" }
         );
         expect(res.status).toHaveBeenCalledWith(200);
         expect(res.json).toHaveBeenCalledWith({

--- a/test/util/signJwt.test.js
+++ b/test/util/signJwt.test.js
@@ -1,0 +1,38 @@
+const jwt = require("jsonwebtoken");
+const { signJwt } = require("../../src/util/signJwt");
+jest.mock("jsonwebtoken");
+
+describe("signJwt", () => {
+    const user = {
+        _id: "1234567890abcdef",
+        timezone: "America/New_York"
+    };
+
+    beforeEach(() => {
+        process.env.JWT_SECRET = "test_secret";
+        jest.spyOn(console, "error").mockImplementation(() => { });
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it("should call jwt.sign with correct payload and options", () => {
+        jwt.sign.mockReturnValue("mockedToken");
+        const token = signJwt(user);
+
+        expect(jwt.sign).toHaveBeenCalledWith(
+            { userId: user._id, timezone: user.timezone },
+            "test_secret",
+            { expiresIn: "7d" }
+        );
+        expect(token).toBe("mockedToken");
+    });
+
+    it("should return the JWT string", () => {
+        jwt.sign.mockReturnValue("test.jwt.token");
+        const token = signJwt(user);
+
+        expect(token).toBe("test.jwt.token");
+    });
+});

--- a/test/util/toCleanCheckIn.test.js
+++ b/test/util/toCleanCheckIn.test.js
@@ -1,0 +1,60 @@
+const { toCleanCheckIn } = require("../../src/util/toCleanCheckIn");
+
+describe("toCleanCheckIn", () => {
+
+    beforeEach(() => {
+        jest.spyOn(console, "error").mockImplementation(() => { });
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it("should convert a Mongoose CheckIn object to a clean object", () => {
+        const mockCheckIn = {
+            _id: { toString: () => "abc123" },
+            habitId: "habit456",
+            habitDay: "2025-07-24",
+            __v: 0, // should be ignored
+            createdAt: new Date("2025-07-20T10:00:00Z") // should be ignored
+        };
+        const result = toCleanCheckIn(mockCheckIn);
+
+        expect(result).toEqual({
+            id: "abc123",
+            habitId: "habit456",
+            habitDay: "2025-07-24"
+        });
+    });
+
+    it("should throw if _id is missing or toString fails", () => {
+        const badCheckIn = {
+            habitId: "habit456",
+            habitDay: "2025-07-24"
+        };
+
+        expect(() => toCleanCheckIn(badCheckIn)).toThrow();
+    });
+
+    it("should include only id, habitId, and habitDay", () => {
+        const mockCheckIn = {
+            _id: { toString: () => "xyz789" },
+            habitId: "habit999",
+            habitDay: "2025-07-23",
+            userId: "user000",
+            createdAt: new Date(),
+            updatedAt: new Date()
+        };
+
+        const result = toCleanCheckIn(mockCheckIn);
+
+        expect(result).toEqual({
+            id: "xyz789",
+            habitId: "habit999",
+            habitDay: "2025-07-23"
+        });
+
+        // Ensure no extra properties
+        expect(Object.keys(result)).toEqual(["id", "habitId", "habitDay"]);
+    });
+});

--- a/test/util/toCleanHabit.test.js
+++ b/test/util/toCleanHabit.test.js
@@ -14,18 +14,17 @@ describe("toCleanHabit", () => {
         const inputHabit = {
             _id: { toString: () => "abc123" },
             name: "Read books",
-            streak: 5,
             createdAt: new Date("2025-07-20T10:00:00Z"),
             __v: 0, // should be ignored
             userId: "user123", // should be ignored
         };
-        const result = toCleanHabit(inputHabit);
+        const result = toCleanHabit(inputHabit, 5);
 
         expect(result).toEqual({
             id: "abc123",
             name: "Read books",
-            streak: 5,
             createdAt: new Date("2025-07-20T10:00:00Z"),
+            streak: 5,
         });
     });
 
@@ -33,26 +32,24 @@ describe("toCleanHabit", () => {
         const inputHabit = {
             _id: { toString: () => "xyz789" },
             name: "",
-            streak: 0,
             createdAt: null,
         };
-        const result = toCleanHabit(inputHabit);
+        const result = toCleanHabit(inputHabit, 0);
 
         expect(result).toEqual({
             id: "xyz789",
             name: "",
-            streak: 0,
             createdAt: null,
+            streak: 0,
         });
     });
 
     it("should throw if _id is missing", () => {
         const inputHabit = {
             name: "No ID",
-            streak: 1,
             createdAt: new Date(),
         };
 
-        expect(() => toCleanHabit(inputHabit)).toThrow();
+        expect(() => toCleanHabit(inputHabit, 0)).toThrow();
     });
 });


### PR DESCRIPTION
- Add Post Check In route for registering a check in associated with a habit.
- Calculate streaks of each habit only when they are requested via Get Habits route. This avoids the need for a daily background job (for now).
- Clear all user streaks when timezone is changed to avoid complicated streak calculation logic.